### PR TITLE
path.join no longer accepts non-string arguments.

### DIFF
--- a/lib/flow.js
+++ b/lib/flow.js
@@ -140,7 +140,7 @@ var Flow = function( config, igneous_config ){
 		flow.files = {};
 		flow.data = '';
 		
-		var base = path.join( igneous_config.root, config.base );
+		var base = config.base?path.join( igneous_config.root, config.base ):igneous_config.root;
 
 		// Loop through paths adding all files found to the files object
 		var addFiles = function( paths, root ){
@@ -275,8 +275,9 @@ var Flow = function( config, igneous_config ){
 	flow.watch = function(){
 
 		var file_paths = config.paths.map( function( file_path ){
+            if(!config.base) file_path = path.join( igneous_config.root, file_path );
 
-			file_path = path.join( igneous_config.root, config.base, file_path );
+			else file_path = path.join( igneous_config.root, config.base, file_path );
 			var exists = fs.existsSync( file_path );
 
 			if( exists ){


### PR DESCRIPTION
...h.join to throw an error.
